### PR TITLE
Minor changes for ease of install, use, security, documentation tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ venv.bak/
 # mypy
 .mypy_cache/
 /vulr
+
+# Secrets
+*config.yml

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This tool receive as single input parameter the path to the YAML file containing
 ```bash
 $ azmlops --help
 $ azmlops job {local path to job config}.yml
-# E.g. ./examples/job_config.yml, whjch you can create based on ./examples/job_config_example.yml
+# E.g. ./examples/job_config.yml, which you can create based on ./examples/job_config_example.yml
 $ azmlops pipeline {local path to pipeline config}.yml 
 # E.g. ./examples/pipeline_config.yml, which you can create based on ./examples/pipeline_config_example.yml
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Other main reasons for the development of this tool have been the transparent su
 ## Install
 
 ```bash
-$ pip install azmlops
+$ git clone git@github.com:JacopoMangiavacchi/azmlops.git
+$ pip install ./azmlops
 ```
 
 ## Usage
@@ -24,8 +25,10 @@ This tool receive as single input parameter the path to the YAML file containing
 
 ```bash
 $ azmlops --help
-$ azmlops job path_to_job_config.yaml
-$ azmlops pipeline path_to_pipeline_config.yaml
+$ azmlops job {local path to job config}.yml
+# E.g. ./examples/job_config.yml, whjch you can create based on ./examples/job_config_example.yml
+$ azmlops pipeline {local path to pipeline config}.yml 
+# E.g. ./examples/pipeline_config.yml, which you can create based on ./examples/pipeline_config_example.yml
 ```
 
 Calling the CLI tool with success will return a URL for monitoring in the Azure ML Studio web portal the execution and logs of Experiments about the submitted Jobs or Pipelines.
@@ -34,11 +37,12 @@ Calling the CLI tool with success will return a URL for monitoring in the Azure 
 
 This tool is implemented in Python 3.8 and it use the Azure ML Python SDK to create and submit data connection and scripts to an AML Compute environment such as a Azure Batch cluster or a VM.
 
-This tool depends on the following requirements:
+This tool depends on the following requirements, which are installed with it:
 
 ```text
 azureml
 azureml-core
+azureml-pipeline
 click
 pyyaml
 ```
@@ -164,9 +168,9 @@ The path to the data in the datastore can be the root (/), a directory within th
 
 ### DataSet
 
-As DataReference Dataset is a reference to data in a Datastore and it is created specifying a specific path to the root (/), a directory within the datastore, or a file in the datastore.
+A Dataset is a reference to data in a Datastore and it is created specifying a specific path to the root (/), a directory within the datastore, or a file in the datastore.
 
-The main difference between a DataSet and a DataReference is that DataSet are mounted through the Linux FUSE kernel module as Read-only volume and therefor they guarantee the **data immutability** pattern when running Jobs and Pipelines.
+The main difference between a DataSet and a DataReference is that DataSet are mounted through the Linux FUSE kernel module as Read-only volume and therefore they guarantee the **data immutability** pattern when running Jobs and Pipelines.
 
 > The **azmlops** tool use DataSet or DataReference for Input data and DataReference for output data.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Other main reasons for the development of this tool have been the transparent su
 $ pip install azmlops
 ```
 
+## Local install from source code
+
+```bash
+$ python setup.py install
+```
+
 ## Usage
 
 This tool receive as single input parameter the path to the YAML file containing the configuration of the Job or Pipeline to run.
@@ -39,6 +45,7 @@ This tool depends on the following requirements:
 ```text
 azureml
 azureml-core
+azureml-pipeline
 click
 pyyaml
 ```

--- a/examples/job_config_example.yml
+++ b/examples/job_config_example.yml
@@ -1,6 +1,7 @@
+# Copy into git ignored *config.yml file and enter your own details
 ---
 name: Copy_Data_Job
-provider: 
+provider:
   azureml:
     workspace:
       subscription_id: subscription_id
@@ -9,15 +10,15 @@ provider:
     compute_name: cluster
 job:
   code:
-    folder: copy_data_scripts
+    folder: examples/copy_data_scripts
     main: main.py
   inputs:
   - input_data
   outputs:
   - output_data
   parameters:
-    input_file: test.txt
-    output_file: test1.txt
+    input_file: test.txt # Pre-existing file in your input datastore
+    output_file: test1.txt # File to create in your output datastore
   environment:
     name: experiment_env
     dependencies:
@@ -28,12 +29,12 @@ data:
   input_data:
     type: dataset
     parameter_name: input_path
-    mount_path: input
+    mount_path: /
     datastore:
       name: input_datastore
   output_data:
     type: datareference
     parameter_name: output_path
-    mount_path: output
+    mount_path: /
     datastore:
       name: output_datastore

--- a/examples/pipeline_config_example.yml
+++ b/examples/pipeline_config_example.yml
@@ -1,6 +1,7 @@
+# Copy into git ignored *config.yml file and enter your own details
 ---
 name: Copy_Data_Pipeline
-provider: 
+provider:
   azureml:
     workspace:
       subscription_id: subscription_id
@@ -10,19 +11,19 @@ provider:
 jobs:
 - copy_data1:
     code:
-      folder: copy_data_scripts
+      folder: examples/copy_data_scripts
       main: main.py
     inputs:
     - input_data
     outputs:
     - pipeline_data
     parameters:
-      input_file: test.txt
-      output_file: test1.txt
+      input_file: test.txt # Pre-existing file in your input datastore
+      output_file: test1.txt # File to create in your output datastore
     environment: experiment_env
 - copy_data2:
     code:
-      folder: copy_data_scripts
+      folder: examples/copy_data_scripts
       main: main.py
     inputs:
     - pipeline_data
@@ -35,13 +36,13 @@ data:
   input_data:
     type: datareference
     parameter_name: input_path
-    mount_path: input
+    mount_path: /
     datastore:
       name: input_datastore
   output_data:
     type: datareference
     parameter_name: output_path
-    mount_path: output
+    mount_path: /
     datastore:
       name: output_datastore
   pipeline_data:

--- a/examples/pipeline_config_example.yml
+++ b/examples/pipeline_config_example.yml
@@ -1,0 +1,60 @@
+# Copy into git ignored *config.yml file and enter your own details
+---
+name: Copy_Data_Pipeline
+provider:
+  azureml:
+    workspace:
+      subscription_id: subscription_id
+      resource_group: resource_group
+      workspace_name: workspace_name
+    compute_name: cluster
+jobs:
+- copy_data1:
+    code:
+      folder: examples/copy_data_scripts
+      main: main.py
+    inputs:
+    - input_data
+    outputs:
+    - pipeline_data
+    parameters:
+      input_file: test.txt # Pre-existing file in your input datastore
+      output_file: test1.txt # File to create in your output datastore
+    environment: experiment_env
+- copy_data2:
+    code:
+      folder: examples/copy_data_scripts
+      main: main.py
+    inputs:
+    - pipeline_data
+    - output_data
+    parameters:
+      input_file: test1.txt
+      output_file: output2.txt
+    environment: experiment_env
+data:
+  input_data:
+    type: datareference
+    parameter_name: input_path
+    mount_path: /
+    datastore:
+      name: input_datastore
+  output_data:
+    type: datareference
+    parameter_name: output_path
+    mount_path: /
+    datastore:
+      name: output_datastore
+  pipeline_data:
+    type: pipelinedata
+    input_parameter_name: input_path
+    output_parameter_name: output_path
+    datastore:
+      name: output_datastore
+environments:
+  experiment_env:
+    name: experiment_env
+    dependencies:
+    - python=3.7
+    - pip:
+      - azureml-defaults

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 azureml
 azureml-core
+azureml-pipeline
 click
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-azureml
-azureml-core
-click
-pyyaml
+azureml==0.2.7
+azureml-core==1.27.0
+azureml-pipeline==1.27.0
+click==7.1.2
+pyyaml==5.4.1


### PR DESCRIPTION
Hi Jacopo. I have maybe a couple of separate issues to raise which require more targeted PRs. But as I was installing and using the package on an Ubuntu 18.04 system running Python 3.8, I needed to make a few changes to get everything working - particularly without prior knowledge. So, I've made some changes with the aim of making this easier for others to adopt.

# Changes

Added `azureml-pipeline` to `requirements.txt` to avoid the following error:

```bash
(azmlopspy38) projects ❯ azmlops --help
Traceback (most recent call last):
  File "/home/masoncusack/projects/azmlops/azmlopspy38/bin/azmlops", line 5, in <module>
    from azmlops.__main__ import main
  File "/home/masoncusack/projects/azmlops/azmlopspy38/lib/python3.8/site-packages/azmlops/__main__.py", line 3, in <module>
    from .aml_utilities import get_configuration, connect_workspace, connect_all_data, submit_job, submit_pipeline
  File "/home/masoncusack/projects/azmlops/azmlopspy38/lib/python3.8/site-packages/azmlops/aml_utilities.py", line 7, in <module>
    from azureml.pipeline.core import Pipeline, PipelineData
ModuleNotFoundError: No module named 'azureml.pipeline'
```

Pinned requirements to those I've seen working (optional, but potentially nice for stability):

```
azureml==0.2.7
azureml-core==1.27.0
azureml-pipeline==1.27.0
click==7.1.2
pyyaml==5.4.1
```

Obscured potential secrets in job and pipeline config files by adding suffix “example” to the examples given, and instructing to duplicate and fill these in with gitignored names (*config.yml), e.g. `job_config.yml`

Found "folder" value in the example configs was wrong if attempting to run them from the repo root. Unless you cd into `./examples`, the path used to access the scripts resolves to e.g. `/home/masoncusack/projects/azmlops/copy_data_scripts`. I've changed the default value of folder to `examples/copy_data_scripts `, which means the path resolves to `/home/masoncusack/projects/azmlops/examples/copy_data_scripts` and encouraged running from repo root, or indeed providing a path to a separate config. This just felt natural but could also be fixed with documentation changes.

I've also changed the default mount paths in the example configs to `/`, which allows them to run out of the box. If you set your input and output datastores up as references to e.g. storage containers, this now "just runs" given `test.txt` exists in container `inputs`, without need for creating more complex paths.

The process of setting up the resources (AML, storage), uploading files, setting up the datastores etc. should all be documented up top too imo, but I'll open a separate issue for this and am happy to help!

# Issues I'll raise separately

- Had problems running locally on MacOS (probably not a priority in which case we should probably recommend an OS, and maybe link to a relevant Azure VM setup doc).

- Need to document _or_ automate all the resource setup required to get up and running - ideally as prerequisites before describing how to submit jobs/pipelines. I think it's best if someone can run examples end-to-end in just a few commands to see what the package does before going deeper into the README.

